### PR TITLE
Allow switching languages midword

### DIFF
--- a/src/io/github/sspanak/tt9/ime/TraditionalT9.java
+++ b/src/io/github/sspanak/tt9/ime/TraditionalT9.java
@@ -353,7 +353,6 @@ public class TraditionalT9 extends KeyPadHandler {
 			mInputMode.clearWordStem();
 			clearSuggestions();
 			getSuggestions();
-			resetKeyRepeat();
 
 			statusBar.setText(mInputMode.toString());
 			mainView.render();

--- a/src/io/github/sspanak/tt9/ime/TraditionalT9.java
+++ b/src/io/github/sspanak/tt9/ime/TraditionalT9.java
@@ -349,14 +349,17 @@ public class TraditionalT9 extends KeyPadHandler {
 
 	public boolean onKeyNextLanguage() {
 		if (nextLang()) {
-			commitCurrentSuggestion(false);
 			mInputMode.changeLanguage(mLanguage);
-			mInputMode.reset();
+			mInputMode.clearWordStem();
+			getSuggestions();
 			resetKeyRepeat();
-			clearSuggestions();
+
 			statusBar.setText(mInputMode.toString());
 			mainView.render();
 			forceShowWindowIfHidden();
+			if (!isSuggestionViewHidden()) {
+				UI.toastLang(getMainContext(), mInputMode.toString());
+			}
 
 			return true;
 		}

--- a/src/io/github/sspanak/tt9/ime/TraditionalT9.java
+++ b/src/io/github/sspanak/tt9/ime/TraditionalT9.java
@@ -351,20 +351,19 @@ public class TraditionalT9 extends KeyPadHandler {
 		if (nextLang()) {
 			mInputMode.changeLanguage(mLanguage);
 			mInputMode.clearWordStem();
+			clearSuggestions();
 			getSuggestions();
 			resetKeyRepeat();
 
 			statusBar.setText(mInputMode.toString());
 			mainView.render();
 			forceShowWindowIfHidden();
-			if (!isSuggestionViewHidden()) {
+			if (mInputMode.isABC() && !isSuggestionViewHidden()) {
 				UI.toastLang(getMainContext(), mInputMode.toString());
 			}
-
-			return true;
 		}
 
-		return false;
+		return true;
 	}
 
 
@@ -574,9 +573,8 @@ public class TraditionalT9 extends KeyPadHandler {
 			return false;
 		}
 
-		// when only one language is enabled, just acknowledge the key was pressed
 		if (mEnabledLanguages.size() < 2) {
-			return true;
+			return false;
 		}
 
 		// select the next language

--- a/src/io/github/sspanak/tt9/ime/modes/ModeABC.java
+++ b/src/io/github/sspanak/tt9/ime/modes/ModeABC.java
@@ -4,8 +4,6 @@ import androidx.annotation.NonNull;
 
 import io.github.sspanak.tt9.languages.Language;
 
-import java.util.ArrayList;
-
 public class ModeABC extends InputMode {
 	public int getId() { return MODE_ABC; }
 
@@ -19,16 +17,15 @@ public class ModeABC extends InputMode {
 
 	@Override
 	public boolean onNumber(int number, boolean hold, int repeat) {
-		digit = number;
 		if (hold) {
 			reset();
-			digit = -1;
-			suggestions.add(String.valueOf(number));
 			autoAcceptTimeout = 0;
+			suggestions.add(String.valueOf(number));
 		} else if (repeat > 0) {
 			shouldSelectNextLetter = true;
 		} else {
 			reset();
+			digit = number;
 			suggestions.addAll(language.getKeyCharacters(number));
 		}
 
@@ -42,12 +39,17 @@ public class ModeABC extends InputMode {
 	}
 
 	@Override
-	public void changeLanguage(Language language) {
-		super.changeLanguage(language);
+	public void changeLanguage(Language newLanguage) {
+		if (newLanguage != language) {
+			suggestions.clear();
+			suggestions.addAll(newLanguage.getKeyCharacters(digit));
+		}
+
+		super.changeLanguage(newLanguage);
 
 		allowedTextCases.clear();
 		allowedTextCases.add(CASE_LOWER);
-		if (language.hasUpperCase()) {
+		if (newLanguage.hasUpperCase()) {
 			allowedTextCases.add(CASE_UPPER);
 		}
 	}
@@ -66,6 +68,7 @@ public class ModeABC extends InputMode {
 	public void reset() {
 		super.reset();
 		shouldSelectNextLetter = false;
+		digit = -1;
 	}
 
 	@NonNull
@@ -84,23 +87,13 @@ public class ModeABC extends InputMode {
 	}
 
 	@Override
-	public ArrayList<String> getSuggestions() {
-		suggestions.clear();
-		if (digit != -1) {
-			suggestions.addAll(language.getKeyCharacters(digit));
-		}
-
-		return super.getSuggestions();
-	}
-
-	@Override
 	public void onAcceptSuggestion(String currentWord) {
 		digit = -1;
 	}
 
 	@Override
 	public boolean onBackspace() {
-		digit = -1;
+		reset();
 		return false;
 	}
 }

--- a/src/io/github/sspanak/tt9/ime/modes/ModeABC.java
+++ b/src/io/github/sspanak/tt9/ime/modes/ModeABC.java
@@ -10,7 +10,7 @@ public class ModeABC extends InputMode {
 	public int getId() { return MODE_ABC; }
 
 	private boolean shouldSelectNextLetter = false;
-	private int lastKey = -1;
+	private int digit = -1;
 
 	ModeABC(Language lang) {
 		changeLanguage(lang);
@@ -19,10 +19,10 @@ public class ModeABC extends InputMode {
 
 	@Override
 	public boolean onNumber(int number, boolean hold, int repeat) {
-		lastKey = number;
+		digit = number;
 		if (hold) {
 			reset();
-			lastKey = -1;
+			digit = -1;
 			suggestions.add(String.valueOf(number));
 			autoAcceptTimeout = 0;
 		} else if (repeat > 0) {
@@ -86,8 +86,8 @@ public class ModeABC extends InputMode {
 	@Override
 	public ArrayList<String> getSuggestions() {
 		suggestions.clear();
-		if (lastKey != -1) {
-			suggestions.addAll(language.getKeyCharacters(lastKey));
+		if (digit != -1) {
+			suggestions.addAll(language.getKeyCharacters(digit));
 		}
 
 		return super.getSuggestions();
@@ -95,12 +95,12 @@ public class ModeABC extends InputMode {
 
 	@Override
 	public void onAcceptSuggestion(String currentWord) {
-		lastKey = -1;
+		digit = -1;
 	}
 
 	@Override
 	public boolean onBackspace() {
-		lastKey = -1;
+		digit = -1;
 		return false;
 	}
 }

--- a/src/io/github/sspanak/tt9/ime/modes/ModeABC.java
+++ b/src/io/github/sspanak/tt9/ime/modes/ModeABC.java
@@ -4,10 +4,13 @@ import androidx.annotation.NonNull;
 
 import io.github.sspanak.tt9.languages.Language;
 
+import java.util.ArrayList;
+
 public class ModeABC extends InputMode {
 	public int getId() { return MODE_ABC; }
 
 	private boolean shouldSelectNextLetter = false;
+	private int lastKey = -1;
 
 	ModeABC(Language lang) {
 		changeLanguage(lang);
@@ -16,8 +19,10 @@ public class ModeABC extends InputMode {
 
 	@Override
 	public boolean onNumber(int number, boolean hold, int repeat) {
+		lastKey = number;
 		if (hold) {
 			reset();
+			lastKey = -1;
 			suggestions.add(String.valueOf(number));
 			autoAcceptTimeout = 0;
 		} else if (repeat > 0) {
@@ -76,5 +81,26 @@ public class ModeABC extends InputMode {
 		String modeString =  language.getAbcString() + " / " + langCode.toUpperCase();
 
 		return (textCase == CASE_LOWER) ? modeString.toLowerCase(language.getLocale()) : modeString.toUpperCase(language.getLocale());
+	}
+
+	@Override
+	public ArrayList<String> getSuggestions() {
+		suggestions.clear();
+		if (lastKey != -1) {
+			suggestions.addAll(language.getKeyCharacters(lastKey));
+		}
+
+		return super.getSuggestions();
+	}
+
+	@Override
+	public void onAcceptSuggestion(String currentWord) {
+		lastKey = -1;
+	}
+
+	@Override
+	public boolean onBackspace() {
+		lastKey = -1;
+		return false;
 	}
 }

--- a/src/io/github/sspanak/tt9/ime/modes/helpers/Predictions.java
+++ b/src/io/github/sspanak/tt9/ime/modes/helpers/Predictions.java
@@ -22,6 +22,7 @@ public class Predictions {
 	private boolean isStemFuzzy;
 	private String stem;
 	private String inputWord;
+	private boolean inputWordMightBeForeign;
 
 	// async operations
 	private Handler wordsChangedHandler;
@@ -45,10 +46,15 @@ public class Predictions {
 			maxEmojiSequenceBuilder.append("1");
 		}
 		maxEmojiSequence = maxEmojiSequenceBuilder.toString();
+
+		inputWordMightBeForeign = false;
 	}
 
 
 	public Predictions setLanguage(Language language) {
+		if (language != this.language) {
+			inputWordMightBeForeign = true;
+		}
 		this.language = language;
 		return this;
 	}
@@ -70,6 +76,23 @@ public class Predictions {
 
 	public Predictions setInputWord(String inputWord) {
 		this.inputWord = inputWord.toLowerCase(language.getLocale());
+
+		// Replace characters that don't exist in the language
+		if (inputWordMightBeForeign) {
+			String newInputWord = "";
+			for (int i = 0; i < digitSequence.length() && i < this.inputWord.length(); i++) {
+				ArrayList<String> keyChars = language.getKeyCharacters(digitSequence.charAt(i) - '0', false);
+				if (keyChars.contains(this.inputWord.charAt(i))) {
+					newInputWord += this.inputWord.charAt(i);
+				}
+				else {
+					newInputWord += keyChars.get(0);
+				}
+			}
+			this.inputWord = newInputWord;
+			inputWordMightBeForeign = false;
+		}
+
 		return this;
 	}
 

--- a/src/io/github/sspanak/tt9/ui/UI.java
+++ b/src/io/github/sspanak/tt9/ui/UI.java
@@ -8,6 +8,8 @@ import io.github.sspanak.tt9.ime.TraditionalT9;
 import io.github.sspanak.tt9.preferences.PreferencesActivity;
 
 public class UI {
+	private static Toast langToast = null;
+
 	public static void showAddWordDialog(TraditionalT9 tt9, int language, String currentWord) {
 		Intent awIntent = new Intent(tt9, AddWordAct.class);
 		awIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
@@ -40,5 +42,14 @@ public class UI {
 
 	public static void toastLong(Context context, CharSequence msg) {
 		Toast.makeText(context, msg, Toast.LENGTH_LONG).show();
+	}
+
+	public static void toastLang(Context context, CharSequence msg) {
+		if (langToast != null) {
+			langToast.cancel();
+		}
+
+		langToast = Toast.makeText(context, msg, Toast.LENGTH_SHORT);
+		langToast.show();
 	}
 }


### PR DESCRIPTION
Allows switching languages midword.
When in predictive mode, a new match is searched for based on the previously entered keys, allowing for quick corrections between languages. When in ABC mode, the current letter is not committed, and the letter list is updated.

Since the status bar is no longer visible when typing, immediate feedback is shown by using a toast.