### PR TITLE
Automatic text case improvement

### DIFF
--- a/src/io/github/sspanak/tt9/ime/modes/helpers/AutoTextCase.java
+++ b/src/io/github/sspanak/tt9/ime/modes/helpers/AutoTextCase.java
@@ -7,6 +7,7 @@ import io.github.sspanak.tt9.languages.Language;
 import io.github.sspanak.tt9.preferences.SettingsStore;
 
 public class AutoTextCase {
+	private final Pattern nextToWordRegex = Pattern.compile("\\b$");
 	private final Pattern startOfSentenceRegex = Pattern.compile("(?<!\\.)(^|[.?!¿¡])\\s*$");
 	private final SettingsStore settings;
 
@@ -69,6 +70,10 @@ public class AutoTextCase {
 		// start of sentence, excluding after "..."
 		if (startOfSentenceRegex.matcher(textBeforeCursor).find()) {
 			return InputMode.CASE_CAPITALIZE;
+		}
+
+		if (nextToWordRegex.matcher(textBeforeCursor).find()) {
+			return InputMode.CASE_LOWER;
 		}
 
 		return InputMode.CASE_DICTIONARY;


### PR DESCRIPTION
Lowercase is now enforced, when the cursor is next to or in the middle of a word.

Closes #267