### PR TITLE
added missing contractions

### DIFF
--- a/assets/en-utf8.csv
+++ b/assets/en-utf8.csv
@@ -14,6 +14,44 @@ gi	92
 gnp	79
 gop	95
 god	124
+he's
+she's
+who's
+what're
+what'll
+what'd
+what've
+where're
+where'd
+where've
+where'll
+why's
+why're
+why've
+why'll
+how's
+how've
+how'll
+which's
+which're
+which'd
+which've
+which'll
+this's
+this'd
+this'll
+these're
+these'd
+these'll
+those're
+those'd
+those'll
+here're
+here'd
+here'll
+there're
+there'd
+there'll
 I'd	136
 I'm	116
 id	99


### PR DESCRIPTION
these are all missing English contractions from the dictionary. They are difficult to add because of the apostrophe. It also just makes the built-in dictionary more extensive for users.