### PR TITLE
added workaround to show the window for older Android devices < 9

### DIFF
--- a/src/io/github/sspanak/tt9/ime/TraditionalT9.java
+++ b/src/io/github/sspanak/tt9/ime/TraditionalT9.java
@@ -795,15 +795,16 @@ public class TraditionalT9 extends KeyPadHandler {
 	 * are invisible. This function forces the InputMethodManager to show our window.
 	 */
 	protected void forceShowWindowIfHidden() {
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
-				&& !mInputMode.isPassthrough()
-				&& !isInputViewShown()
-		) {
+		if (mInputMode.isPassthrough() || isInputViewShown()) {
+			return;
+		}
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
 			requestShowSelf(InputMethodManager.SHOW_IMPLICIT);
 		} else {
-			super.showWindow(true);
+			showWindow(true);
 		}
 	}
+
 
 	@Override
 	protected boolean shouldBeVisible() {

--- a/src/io/github/sspanak/tt9/ime/TraditionalT9.java
+++ b/src/io/github/sspanak/tt9/ime/TraditionalT9.java
@@ -803,9 +803,9 @@ public class TraditionalT9 extends KeyPadHandler {
 				&& !mInputMode.isPassthrough()
 				&& !isInputViewShown()
 		) {
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
 			requestShowSelf(InputMethodManager.SHOW_IMPLICIT);
-		}
-		else{
+		} else {
 			super.showWindow(true);
 		}
 	}

--- a/src/io/github/sspanak/tt9/ime/TraditionalT9.java
+++ b/src/io/github/sspanak/tt9/ime/TraditionalT9.java
@@ -799,7 +799,6 @@ public class TraditionalT9 extends KeyPadHandler {
 				&& !mInputMode.isPassthrough()
 				&& !isInputViewShown()
 		) {
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
 			requestShowSelf(InputMethodManager.SHOW_IMPLICIT);
 		} else {
 			super.showWindow(true);

--- a/src/io/github/sspanak/tt9/ime/TraditionalT9.java
+++ b/src/io/github/sspanak/tt9/ime/TraditionalT9.java
@@ -805,8 +805,10 @@ public class TraditionalT9 extends KeyPadHandler {
 		) {
 			requestShowSelf(InputMethodManager.SHOW_IMPLICIT);
 		}
+		else{
+			super.showWindow(true);
+		}
 	}
-
 
 	@Override
 	protected boolean shouldBeVisible() {


### PR DESCRIPTION
Problem:
As previously asked, there did not seem to be a method to handle the keyboard's main view from not showing. I have tested this method for my Sonim (which runs Android 8.1 and could not take advantage of requestShowSelf) and it is working now.
Solution:
Call showWindow(), which makes a call to showWindowInner() with the boolean you pass. When you pass true, attributes such as mShowInputRequested and mWindowVisible become true, which help assist in functions like updateInputViewShown()