### PR TITLE
changed onBackspace to first shorten the digitSequence and then deter…

### DIFF
--- a/src/io/github/sspanak/tt9/ime/TraditionalT9.java
+++ b/src/io/github/sspanak/tt9/ime/TraditionalT9.java
@@ -300,12 +300,7 @@ public class TraditionalT9 extends KeyPadHandler {
 			return performOKAction();
 		}
 
-		String word = suggestionBar.getCurrentSuggestion();
-
-		mInputMode.onAcceptSuggestion(word);
-		commitCurrentSuggestion();
-		autoCorrectSpace(word, true, KeyEvent.KEYCODE_ENTER);
-		resetKeyRepeat();
+		acceptCurrentSuggestion(KeyEvent.KEYCODE_ENTER);
 
 		return true;
 	}
@@ -505,10 +500,10 @@ public class TraditionalT9 extends KeyPadHandler {
 		cancelAutoAccept();
 
 		if (delay == 0) {
-			this.onOK();
+			this.acceptCurrentSuggestion();
 			return true;
 		} else if (delay > 0) {
-			autoAcceptHandler.postDelayed(this::autoAccept, delay);
+			autoAcceptHandler.postDelayed(this::acceptCurrentSuggestion, delay);
 		}
 
 		return false;
@@ -520,10 +515,20 @@ public class TraditionalT9 extends KeyPadHandler {
 	}
 
 
-	private void autoAccept() {
-		if (suggestionBar.hasElements()) {
-			this.onOK();
+	private void acceptCurrentSuggestion(int fromKey) {
+		String word = suggestionBar.getCurrentSuggestion();
+		if (word.isEmpty()) {
+			return;
 		}
+
+		mInputMode.onAcceptSuggestion(word);
+		commitCurrentSuggestion();
+		autoCorrectSpace(word, true, fromKey);
+		resetKeyRepeat();
+	}
+
+	private void acceptCurrentSuggestion() {
+		acceptCurrentSuggestion(-1);
 	}
 
 
@@ -798,6 +803,7 @@ public class TraditionalT9 extends KeyPadHandler {
 		if (mInputMode.isPassthrough() || isInputViewShown()) {
 			return;
 		}
+
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
 			requestShowSelf(InputMethodManager.SHOW_IMPLICIT);
 		} else {

--- a/src/io/github/sspanak/tt9/ime/modes/ModePredictive.java
+++ b/src/io/github/sspanak/tt9/ime/modes/ModePredictive.java
@@ -51,6 +51,9 @@ public class ModePredictive extends InputMode {
 
 	@Override
 	public boolean onBackspace() {
+		if (digitSequence.isEmpty()) {
+			return false;
+		}
 		digitSequence = digitSequence.substring(0, digitSequence.length() - 1);
 		if (digitSequence.length() < 1) {
 			clearWordStem();

--- a/src/io/github/sspanak/tt9/ime/modes/ModePredictive.java
+++ b/src/io/github/sspanak/tt9/ime/modes/ModePredictive.java
@@ -57,6 +57,7 @@ public class ModePredictive extends InputMode {
 		digitSequence = digitSequence.substring(0, digitSequence.length() - 1);
 		if (digitSequence.length() < 1) {
 			clearWordStem();
+			reset();
 			return false;
 		}
 

--- a/src/io/github/sspanak/tt9/ime/modes/ModePredictive.java
+++ b/src/io/github/sspanak/tt9/ime/modes/ModePredictive.java
@@ -51,15 +51,13 @@ public class ModePredictive extends InputMode {
 
 	@Override
 	public boolean onBackspace() {
+		digitSequence = digitSequence.substring(0, digitSequence.length() - 1);
 		if (digitSequence.length() < 1) {
 			clearWordStem();
 			return false;
 		}
 
-		digitSequence = digitSequence.substring(0, digitSequence.length() - 1);
-		if (digitSequence.length() == 0) {
-			clearWordStem();
-		} else if (stem.length() > digitSequence.length()) {
+		if (stem.length() > digitSequence.length()) {
 			stem = stem.substring(0, digitSequence.length() - 1);
 		}
 


### PR DESCRIPTION
Problem:
Even when deleting the first letter in a word, getSuggestions() is being called because onBackspace was returning true. The concern here was that digitSequence and suggestions need to be clear before beginning to type another word.

Solution:
Shorten digitSequence by 1 immediately. This makes sure that when deleting the last letter, the digitSequence is "".
suggestions are already cleared by onNumber() in ModePredictive.java. It calls for super.reset(), which clears suggestions.
This solution will make the code not run an extra step of trying to load suggestions which do not exist.