### PR TITLE
remove an unnecessary shouldBeOff() refernce

### DIFF
--- a/src/io/github/sspanak/tt9/ime/TraditionalT9.java
+++ b/src/io/github/sspanak/tt9/ime/TraditionalT9.java
@@ -747,10 +747,6 @@ public class TraditionalT9 extends KeyPadHandler {
 
 
 	private void showAddWord() {
-		if (shouldBeOff()) {
-			return;
-		}
-
 		textField.finishComposingText();
 		clearSuggestions();
 


### PR DESCRIPTION
Problem:
shouldBeOff() was called where it was unnecessary. shouldBeOff() is already called on onKeyUP, onKeyDown, and onKeyLongPress, so it is already handled before it would ever get to an Add word scenario.

Solution:
Remove call to shouldBeOff from inside showAddWord()