### PR TITLE
New Sentence Case

### DIFF
--- a/src/io/github/sspanak/tt9/TextTools.java
+++ b/src/io/github/sspanak/tt9/TextTools.java
@@ -7,7 +7,7 @@ public class TextTools {
 	private static final Pattern previousIsLetter = Pattern.compile("\\p{L}$");
 	private static final Pattern nextIsPunctuation = Pattern.compile("^\\p{Punct}");
 	private static final Pattern nextToWord = Pattern.compile("\\b$");
-	private static final Pattern startOfSentence = Pattern.compile("(?<!\\.)(^|[.?!¿¡])\\s*$");
+	private static final Pattern startOfSentence = Pattern.compile("(?<!\\.)(^|[.?!¿¡])\\s+$");
 
 	public static boolean containsOtherThan1(String str) {
 		return str != null && containsOtherThan1.matcher(str).find();


### PR DESCRIPTION
Problem:
while still typing a period in the middle of a sentence (such as wanting to type .com), the case of the C after the period was being suggested as a capital because it was treated as a new sentence. A new sentence does not begin after a period, but after the space after the period.

Solution:
Fixed regex which was fine with 0 instances of a space (/s), to have to include at least 1 space. This is allowing users to type .com naturally, instead of .Com