### PR TITLE
remove fadingEdge because it is deprecated

### DIFF
--- a/res/layout/main_numpad.xml
+++ b/res/layout/main_numpad.xml
@@ -21,7 +21,6 @@
 			android:id="@+id/suggestions_bar"
 			android:layout_width="match_parent"
 			android:layout_height="match_parent"
-			android:fadingEdge="horizontal"
 			android:gravity="center"
 			android:orientation="horizontal"
 			android:scrollbars="none" />

--- a/res/layout/main_small.xml
+++ b/res/layout/main_small.xml
@@ -22,7 +22,6 @@
 			android:gravity="center_vertical"
 			android:layout_width="match_parent"
 			android:layout_height="match_parent"
-			android:fadingEdge="horizontal"
 			android:orientation="horizontal"
 			android:scrollbars="none" />
 


### PR DESCRIPTION
Problem:
XML attribute "fadingEdge" is applied to RecyclerView, however it is just being ignored:
 <!-- This attribute is ignored in API level 14
             ({@link android.os.Build.VERSION_CODES#ICE_CREAM_SANDWICH}) and higher.
             Using fading edges may introduce noticeable performance
             degradations and should be used only when required by the application's
             visual design. To request fading edges with API level 14 and above,
             use the <code>android:requiresFadingEdge</code> attribute instead. -->
        <attr name="fadingEdge">

More info: https://developer.android.com/reference/android/R.attr.html#fadingEdge

Solution: 
Remove unused xml attribute