### PR TITLE
removed the last of the legacy Backspace hack

### DIFF
--- a/src/io/github/sspanak/tt9/ime/KeyPadHandler.java
+++ b/src/io/github/sspanak/tt9/ime/KeyPadHandler.java
@@ -122,7 +122,7 @@ abstract class KeyPadHandler extends InputMethodService {
 		if (Key.isBackspace(settings, keyCode)) {
 			// When there is no more text, allow "Back" key to function normally, not to block navigation.
 			// All other keys have their default function disabled.
-			isBackspaceHandled = onBackspace() || keyCode != KeyEvent.KEYCODE_BACK;
+			isBackspaceHandled = onBackspace();
 			return isBackspaceHandled;
 		} else {
 			isBackspaceHandled = false;

--- a/src/io/github/sspanak/tt9/ime/KeyPadHandler.java
+++ b/src/io/github/sspanak/tt9/ime/KeyPadHandler.java
@@ -120,8 +120,6 @@ abstract class KeyPadHandler extends InputMethodService {
 
 		// "backspace" key must repeat its function when held down, so we handle it in a special way
 		if (Key.isBackspace(settings, keyCode)) {
-			// When there is no more text, allow "Back" key to function normally, not to block navigation.
-			// All other keys have their default function disabled.
 			isBackspaceHandled = onBackspace();
 			return isBackspaceHandled;
 		} else {


### PR DESCRIPTION
Problem:

When testing on a consumer cellular link ii where the clear key also doubles as the back key:
![image](https://github.com/sspanak/tt9/assets/11878115/3987afcc-b516-4851-9d40-5d988cd73e64) and it is meant to delete text when there is text, otherwise double as a back key for system navigation.
I was not able to back out of a text conversation because I would be on a textbox which calls for the keypad and isBackspaceHandled was always returning true here. It wasn't returning true because of onBackspace() but because the keyCode was 67 (KeyEvent.KEYCODE_DEL) and was returning true for the second part of the OR statement.

Solution:

Removed second part of conditional. onBackspace() already checks whether there's text or if it's in passthrough. Open to discussing the logic here, but it doesn't seem necessary to have this OR statement.