### PR TITLE
added OR operator for calculator app

### DIFF
--- a/src/io/github/sspanak/tt9/ime/helpers/InputType.java
+++ b/src/io/github/sspanak/tt9/ime/helpers/InputType.java
@@ -51,7 +51,7 @@ public class InputType {
 		int inputType = field.inputType & android.text.InputType.TYPE_MASK_CLASS;
 
 		return
-			inputType == android.text.InputType.TYPE_CLASS_PHONE && field.packageName.equals("com.android.dialer") || inputType == android.text.InputType.TYPE_CLASS_NUMBER;
+			inputType == android.text.InputType.TYPE_CLASS_PHONE && field.packageName.equals("com.android.dialer") || inputType == android.text.InputType.TYPE_CLASS_NUMBER && field.packageName.contains("com.android.calculator");
 	}
 
 

--- a/src/io/github/sspanak/tt9/ime/helpers/InputType.java
+++ b/src/io/github/sspanak/tt9/ime/helpers/InputType.java
@@ -51,7 +51,7 @@ public class InputType {
 		int inputType = field.inputType & android.text.InputType.TYPE_MASK_CLASS;
 
 		return
-			inputType == android.text.InputType.TYPE_CLASS_PHONE && field.packageName.equals("com.android.dialer");
+			inputType == android.text.InputType.TYPE_CLASS_PHONE && field.packageName.equals("com.android.dialer") || inputType == android.text.InputType.TYPE_CLASS_NUMBER;
 	}
 
 

--- a/src/io/github/sspanak/tt9/ime/helpers/InputType.java
+++ b/src/io/github/sspanak/tt9/ime/helpers/InputType.java
@@ -33,17 +33,18 @@ public class InputType {
 
 
 	/**
-	 * isDialer
-	 * Dialer fields seem to take care of numbers and backspace on their own,
+	 * isSpecialNumeric
+	 * Calculator and Dialer fields seem to take care of numbers and backspace on their own,
 	 * so we need to be aware of them.
 	 *
 	 * NOTE: A Dialer field is not the same as Phone field. Dialer is where you
 	 * actually dial and call a phone number. While the Phone field is a text
 	 * field in any app or a webpage, intended for typing phone numbers.
 	 *
-	 * More info: <a href="https://github.com/sspanak/tt9/issues/46">in this Github issue</a>.
+	 * More info: <a href="https://github.com/sspanak/tt9/issues/46">in this Github issue</a>
+	 * and <a href="https://github.com/sspanak/tt9/pull/326">the PR about calculators</a>.
 	 */
-	public boolean isDialer() {
+	public boolean isSpecialNumeric() {
 		if (field == null) {
 			return false;
 		}
@@ -51,7 +52,8 @@ public class InputType {
 		int inputType = field.inputType & android.text.InputType.TYPE_MASK_CLASS;
 
 		return
-			inputType == android.text.InputType.TYPE_CLASS_PHONE && field.packageName.equals("com.android.dialer") || inputType == android.text.InputType.TYPE_CLASS_NUMBER && field.packageName.contains("com.android.calculator");
+			inputType == android.text.InputType.TYPE_CLASS_PHONE && field.packageName.equals("com.android.dialer")
+			|| inputType == android.text.InputType.TYPE_CLASS_NUMBER && field.packageName.contains("com.android.calculator");
 	}
 
 

--- a/src/io/github/sspanak/tt9/ime/helpers/TextField.java
+++ b/src/io/github/sspanak/tt9/ime/helpers/TextField.java
@@ -90,9 +90,10 @@ public class TextField {
 			return allowedModes;
 		}
 
-		// Dialer field, not to be confused with Phone text field.
-		// It only accepts 0-9, "#" and "*".
-		if (inputType.isDialer()) {
+		// Calculators (support only 0-9 and math) and Dialer (0-9, "#" and "*"),
+		// handle all input themselves, so we are supposed to pass through all key presses.
+		// Note: A Dialer field is not a Phone number field.
+		if (inputType.isSpecialNumeric()) {
 			allowedModes.add(InputMode.MODE_PASSTHROUGH);
 			return allowedModes;
 		}

--- a/src/io/github/sspanak/tt9/ime/modes/ModePassthrough.java
+++ b/src/io/github/sspanak/tt9/ime/modes/ModePassthrough.java
@@ -2,7 +2,7 @@ package io.github.sspanak.tt9.ime.modes;
 
 import androidx.annotation.NonNull;
 
-// see: InputType.isDialer()
+// see: InputType.isSpecialNumeric()
 public class ModePassthrough extends InputMode {
 	ModePassthrough() {
 		reset();


### PR DESCRIPTION
Problem: When using the Calculator app, the status bar was showing and covering part of the UI. I felt it made more sense to use passthrough here, similar to the dialer. It also allows me to press * and insert a decimal point on the calculator app
![image](https://github.com/sspanak/tt9/assets/11878115/d1519868-4ad4-4f91-a1eb-139321d4dc87)


Solution: in isDialer() function, also consider when the inputType is android.text.InputType.TYPE_CLASS_NUMBER

