### PR TITLE
Restore arrow-key functionality (fixes #341)

### DIFF
--- a/src/io/github/sspanak/tt9/ime/KeyPadHandler.java
+++ b/src/io/github/sspanak/tt9/ime/KeyPadHandler.java
@@ -131,6 +131,15 @@ abstract class KeyPadHandler extends InputMethodService {
 			event.startTracking();
 		}
 
+		if (Key.isArrow(keyCode)) {
+			boolean shouldIgnore = shouldIgnoreKeyUp(keyCode, event);
+			if (shouldIgnore) {
+				return super.onKeyDown(keyCode, event);
+			} else {
+				return onArrow(keyCode, keyRepeatCounter > 0);
+			}
+		}
+
 		return Key.isNumber(keyCode)
 			|| Key.isOK(keyCode)
 			|| Key.isHotkey(settings, keyCode) || Key.isHotkey(settings, -keyCode) // press or hold a hotkey
@@ -219,13 +228,6 @@ abstract class KeyPadHandler extends InputMethodService {
 			return true;
 		}
 
-		switch (keyCode) {
-			case KeyEvent.KEYCODE_DPAD_UP:
-			case KeyEvent.KEYCODE_DPAD_DOWN:
-			case KeyEvent.KEYCODE_DPAD_LEFT:
-			case KeyEvent.KEYCODE_DPAD_RIGHT: return onArrow(keyCode, keyRepeatCounter > 0);
-		}
-
 		// let the system handle the keys we don't care about (usually, only: KEYCODE_BACK)
 		return super.onKeyUp(keyCode, event);
 	}
@@ -284,4 +286,5 @@ abstract class KeyPadHandler extends InputMethodService {
 	abstract protected View createSoftKeyView();
 	abstract protected boolean shouldBeVisible();
 	abstract protected boolean shouldBeOff();
+	abstract protected boolean shouldIgnoreKeyUp(int keyCode, KeyEvent event);
 }

--- a/src/io/github/sspanak/tt9/ime/TraditionalT9.java
+++ b/src/io/github/sspanak/tt9/ime/TraditionalT9.java
@@ -18,6 +18,7 @@ import io.github.sspanak.tt9.Logger;
 import io.github.sspanak.tt9.db.DictionaryDb;
 import io.github.sspanak.tt9.ime.helpers.InputModeValidator;
 import io.github.sspanak.tt9.ime.helpers.InputType;
+import io.github.sspanak.tt9.ime.helpers.Key;
 import io.github.sspanak.tt9.ime.helpers.TextField;
 import io.github.sspanak.tt9.ime.modes.InputMode;
 import io.github.sspanak.tt9.languages.Language;
@@ -797,4 +798,14 @@ public class TraditionalT9 extends KeyPadHandler {
 	protected boolean shouldBeOff() {
 		 return currentInputConnection == null || !isActive || mInputMode.isPassthrough();
 	}
+
+	@Override
+	protected boolean shouldIgnoreKeyUp(int keyCode, KeyEvent event) {
+		if (Key.isArrow(keyCode)) {
+			return isSuggestionViewHidden();
+		} else {
+			return false;
+		}
+	}
+
 }

--- a/src/io/github/sspanak/tt9/ime/helpers/Key.java
+++ b/src/io/github/sspanak/tt9/ime/helpers/Key.java
@@ -41,7 +41,15 @@ public class Key {
 	}
 
 
-	public static int codeToNumber(SettingsStore settings, int keyCode) {
+	public static boolean isArrow(int keyCode) {
+		return
+			keyCode == KeyEvent.KEYCODE_DPAD_UP
+			|| keyCode == KeyEvent.KEYCODE_DPAD_DOWN
+			|| keyCode == KeyEvent.KEYCODE_DPAD_LEFT
+			|| keyCode == KeyEvent.KEYCODE_DPAD_RIGHT;
+	}
+
+		public static int codeToNumber(SettingsStore settings, int keyCode) {
 		switch (keyCode) {
 			case KeyEvent.KEYCODE_0:
 			case KeyEvent.KEYCODE_NUMPAD_0:


### PR DESCRIPTION
Restore arrow-key functionality (use arrow keys to move text cursor & widget focus)

Fixes #341