### PR TITLE
fix handling of 1 key

### DIFF
--- a/src/io/github/sspanak/tt9/db/room/TT9Room.java
+++ b/src/io/github/sspanak/tt9/db/room/TT9Room.java
@@ -29,7 +29,7 @@ public abstract class TT9Room extends RoomDatabase {
 				DB10.MIGRATION,
 				new DB11().getMigration(context)
 			)
-			.build();
+			.allowMainThreadQueries().build();
 	}
 
 	public static SimpleSQLiteQuery getFuzzyQuery(String index, int langId, int limit, String sequence, int minWordLength, int maxWordLength, String word) {

--- a/src/io/github/sspanak/tt9/ime/TraditionalT9.java
+++ b/src/io/github/sspanak/tt9/ime/TraditionalT9.java
@@ -504,7 +504,7 @@ public class TraditionalT9 extends KeyPadHandler {
 		}
 
 		mInputMode.onAcceptSuggestion(word);
-		commitCurrentSuggestion();
+		commitCurrentSuggestion(true);
 		autoCorrectSpace(word, true, fromKey);
 		resetKeyRepeat();
 	}
@@ -520,11 +520,6 @@ public class TraditionalT9 extends KeyPadHandler {
 		commitCurrentSuggestion(false);
 
 		return currentWord;
-	}
-
-
-	private void commitCurrentSuggestion() {
-		commitCurrentSuggestion(true);
 	}
 
 	private void commitCurrentSuggestion(boolean entireSuggestion) {
@@ -552,10 +547,14 @@ public class TraditionalT9 extends KeyPadHandler {
 
 
 	private void handleSuggestions() {
-		// Automatically accept the previous word, without requiring OK. This is similar to what
+		// Automatically accept the previous word, without requiring OK.
 		// Second pass, analyze the available suggestions and decide if combining them with the
 		// last key press makes up a compound word like: (it)'s, (I)'ve, l'(oiseau), or it is
 		// just the end of a sentence, like: "word." or "another?"
+		//
+		// Check to see whether we should commit on symbol use and whether to include
+		// that symbol or not.
+		// If user typed fast, they may be running through this code with a digitSequence of #1##
 		if (mInputMode.shouldAcceptPreviousSuggestion()) {
 			String lastComposingText = getComposingText(mInputMode.getSequenceLength() - 1);
 			commitCurrentSuggestion(false);

--- a/src/io/github/sspanak/tt9/ime/modes/ModePredictive.java
+++ b/src/io/github/sspanak/tt9/ime/modes/ModePredictive.java
@@ -120,7 +120,6 @@ public class ModePredictive extends InputMode {
 		if (
 			lastAcceptedWord.isEmpty()
 			|| suggestions.isEmpty()
-			|| !suggestions.get(0).toLowerCase(language.getLocale()).startsWith(lastAcceptedWord.toLowerCase(language.getLocale()))
 		) {
 			return;
 		}
@@ -324,6 +323,9 @@ public class ModePredictive extends InputMode {
 		/**
 	 * shouldAcceptPreviousSuggestion
 	 * Variant for post suggestion load analysis.
+		 * After suggestions are loaded, check if the user just typed 1,
+		 * if so then suggestion prior to 1 is to be committed as long as
+		 * there is not a suggested word (such as l' in French)
 	 */
 	@Override
 	public boolean shouldAcceptPreviousSuggestion() {
@@ -331,9 +333,9 @@ public class ModePredictive extends InputMode {
 			(autoAcceptTimeout == 0 && !digitSequence.startsWith("0"))
 			|| (
 				!digitSequence.isEmpty()
-				&& !predictions.areThereDbWords()
-				&& digitSequence.contains("1")
-				&& TextTools.containsOtherThan1(digitSequence)
+					&& !predictions.areThereDbWords()
+					&& digitSequence.contains("1")
+				  && TextTools.containsOtherThan1(digitSequence)
 			);
 	}
 

--- a/src/io/github/sspanak/tt9/ime/modes/helpers/AutoSpace.java
+++ b/src/io/github/sspanak/tt9/ime/modes/helpers/AutoSpace.java
@@ -54,7 +54,7 @@ public class AutoSpace {
 			&& !TextTools.startsWithWhitespace(nextChars)
 			&& (
 				shouldAddAfterWord(isWordAcceptedManually, previousChars, nextChars, nextKey)
-				|| shouldAddAfterPunctuation(previousChars, nextChars, nextKey)
+				|| shouldAddAfterPunctuation(isWordAcceptedManually, previousChars, nextChars, nextKey)
 			);
 	}
 
@@ -65,13 +65,14 @@ public class AutoSpace {
 	 * The rules are similar to the ones in the standard Android keyboard (with some exceptions,
 	 * because we are not using a QWERTY keyboard here).
 	 */
-	private boolean shouldAddAfterPunctuation(String previousChars, String nextChars, int nextKey) {
+	private boolean shouldAddAfterPunctuation(boolean isWordAcceptedManually, String previousChars, String nextChars, int nextKey) {
 		char previousChar = previousChars.isEmpty() ? 0 : previousChars.charAt(previousChars.length() - 1);
 
 		return
 			nextKey != 1
 			&& !TextTools.nextIsPunctuation(nextChars)
 			&& !TextTools.startsWithNumber(nextChars)
+				&& isWordAcceptedManually
 			&& (
 				previousChar == '.'
 				|| previousChar == ','


### PR DESCRIPTION
Problem:

I was catching instances where adding the apostrophe when typing "I'm" was not working.
I stepped through this algorithm and found a flaw: handleSuggestions() has the potential to process a digitSequence of 416 depending on how fast you type. Thus producing Imim.
digitSequence of 4 -> I,G,H
digitSequence of 416 -> im,in,io (suggestions get cut to m,n,o in clearLastAcceptedWord() )
digitSequence of 416 again -> im,in,io


![Screenshot_19700101-175512](https://github.com/sspanak/tt9/assets/11878115/d739ad6b-2588-45e4-a87e-cd620f22a539)
![Screenshot from 2023-08-14 13-59-59](https://github.com/sspanak/tt9/assets/11878115/f6c5c2c2-d268-4923-a3f0-5541e60bb2f6)

I have corrected this process to properly process 1 regardless of how fast you type in order to return just punctuation marks on 1, and not i,i.i-, etc which was eventually being trimmed in clearLastAcceptedWord() to just punctuation marks.
I wrote the code to no longer use loadStatic() to load punctuation, since that was breaking up the digitSequence and thus handleSuggestions(), but instead punctuation is later loaded in generatePossibleCompletions()


Lastly, removed a duplicate commitCurrentSuggestion() that was just calling the other function.