### PR TITLE
changed logic to not force show on OK

### DIFF
--- a/src/io/github/sspanak/tt9/ime/TraditionalT9.java
+++ b/src/io/github/sspanak/tt9/ime/TraditionalT9.java
@@ -308,16 +308,10 @@ public class TraditionalT9 extends KeyPadHandler {
 
 	public boolean onOK() {
 		cancelAutoAccept();
-
-		if (!isInputViewShown() && !textField.isThereText()) {
-			forceShowWindowIfHidden();
-			return true;
-		} else if (isSuggestionViewHidden()) {
-			return performOKAction();
+		performOKAction();
+		if (!isSuggestionViewHidden()) {
+			acceptCurrentSuggestion(KeyEvent.KEYCODE_ENTER);
 		}
-
-		acceptCurrentSuggestion(KeyEvent.KEYCODE_ENTER);
-
 		return true;
 	}
 

--- a/src/io/github/sspanak/tt9/ime/TraditionalT9.java
+++ b/src/io/github/sspanak/tt9/ime/TraditionalT9.java
@@ -308,8 +308,10 @@ public class TraditionalT9 extends KeyPadHandler {
 
 	public boolean onOK() {
 		cancelAutoAccept();
-		performOKAction();
-		if (!isSuggestionViewHidden()) {
+
+		if (isSuggestionViewHidden()) {
+			return performOKAction();
+		} else {
 			acceptCurrentSuggestion(KeyEvent.KEYCODE_ENTER);
 		}
 		return true;


### PR DESCRIPTION
Since we are now forcing the view on number presses, I removed the logic to force show on OK. I think this is a more user-friendly experience, as the user would be able to use the D-Pad & OK key for system functions, but if they intend to type, they can press a number key and the UI would show.
This has turned out nicely for my Contacts screen, which has a search bar on top and some contacts to scroll/select on the bottom. I can now use OK to select a contact on first press of OK instead of it initializing the keyboard UI.
Before:
![Screenshot_20230822-120310](https://github.com/sspanak/tt9/assets/11878115/fabe5513-c087-44fd-8fa8-4481f8d69d49)
After:
![Screenshot_20230822-140947](https://github.com/sspanak/tt9/assets/11878115/7808a8b6-cfe8-45aa-8433-d86c43ee0110)
Secondly, I added logic to call acceptCurrentSuggestion only when the suggestion bar is showing.