### PR TITLE
remove onstop

### DIFF
--- a/src/io/github/sspanak/tt9/ime/KeyPadHandler.java
+++ b/src/io/github/sspanak/tt9/ime/KeyPadHandler.java
@@ -93,17 +93,6 @@ abstract class KeyPadHandler extends InputMethodService {
 		onFinishTyping();
 	}
 
-	/**
-	 * This is called when the user is done editing a field. We can use this to
-	 * reset our state.
-	 */
-	@Override
-	public void onFinishInput() {
-		super.onFinishInput();
-		// Logger.d("onFinishInput", "When is this called?");
-		onStop();
-	}
-
 
 	/**
 	 * Use this to monitor key events being delivered to the application. We get

--- a/src/io/github/sspanak/tt9/ime/KeyPadHandler.java
+++ b/src/io/github/sspanak/tt9/ime/KeyPadHandler.java
@@ -277,7 +277,6 @@ abstract class KeyPadHandler extends InputMethodService {
 	abstract protected void onStart(EditorInfo inputField);
 	abstract protected void onRestart(EditorInfo inputField);
 	abstract protected void onFinishTyping();
-	abstract protected void onStop();
 
 	// UI
 	abstract protected View createSoftKeyView();

--- a/src/io/github/sspanak/tt9/ime/TraditionalT9.java
+++ b/src/io/github/sspanak/tt9/ime/TraditionalT9.java
@@ -205,7 +205,6 @@ public class TraditionalT9 extends KeyPadHandler {
 
 		if (!inputType.isValid() || inputType.isLimited()) {
 			// When the input is invalid or simple, let Android handle it.
-			onStop();
 			return;
 		}
 
@@ -226,13 +225,6 @@ public class TraditionalT9 extends KeyPadHandler {
 	protected void onFinishTyping() {
 		cancelAutoAccept();
 		isActive = false;
-	}
-
-
-	protected void onStop() {
-		onFinishTyping();
-		clearSuggestions();
-		statusBar.setText("--");
 	}
 
 


### PR DESCRIPTION
onStop is called during onStart (opening UI) and onFinishInput (closing UI)
it consists of three functions
1. onFinishTyping() - closes autoAccept handler
2. clearSuggestions() - clears existing suggestions
3. statusBar.selectText() - changes status bar to show input mode

I've found that by removing onStop, when you leave and come back to type, these 3 functions are called anyway.
onFinishTyping() is called by onFinishInputView() when you leave the keyboard.
clearSuggestions() main tasks are to setSuggestions to null, which is done during onStartInput when you open the keyboard back up and to set composing text to "". I've found this is not making a difference when you leave the keyboard anyway, as this existing suggestion gets committed anyway.
statusBar.selectText is called when you open the keyboard again.
