### PR TITLE
fixed duplicate tasks

### DIFF
--- a/src/io/github/sspanak/tt9/ime/TraditionalT9.java
+++ b/src/io/github/sspanak/tt9/ime/TraditionalT9.java
@@ -354,7 +354,6 @@ public class TraditionalT9 extends KeyPadHandler {
 		}
 
 		cancelAutoAccept();
-		textField.finishComposingText();
 		clearSuggestions();
 
 		String word = textField.getSurroundingWord();
@@ -445,7 +444,6 @@ public class TraditionalT9 extends KeyPadHandler {
 
 		cancelAutoAccept();
 		commitCurrentSuggestion(false);
-		clearSuggestions();
 		resetKeyRepeat();
 		nextLang();
 		mInputMode.changeLanguage(mLanguage);


### PR DESCRIPTION
Found some duplicate tasks
1. onKeyAddWord: calling textField.finishComposingText() and clearSuggestions(), but in clearSuggestions(), textField.finishComposingText() is called too
2. onKeyNextLanguage: commitCurrentSuggestion() is called which also runs the same tasks as clearSuggestions, and then clearSuggestions() is being called after that. I am sure there is some re-factoring of this logic that can be done, but for now just focusing on removing duplicate tasks