### PR TITLE
added new flag and added text check

### DIFF
--- a/src/io/github/sspanak/tt9/ime/TraditionalT9.java
+++ b/src/io/github/sspanak/tt9/ime/TraditionalT9.java
@@ -732,19 +732,20 @@ public class TraditionalT9 extends KeyPadHandler {
 				String oldText = textField.getTextBeforeCursor() + textField.getTextAfterCursor();
 
 				sendDownUpKeyEvents(KeyEvent.KEYCODE_DPAD_CENTER);
-
-				try {
-					// In Android there is no strictly defined confirmation key, hence DPAD_CENTER may have done nothing.
-					// If so, send an alternative key code as a final resort.
-					Thread.sleep(80);
-					String newText = textField.getTextBeforeCursor() + textField.getTextAfterCursor();
-					if (newText.equals(oldText)) {
-						sendDownUpKeyEvents(KeyEvent.KEYCODE_ENTER);
+				if (!oldText.isEmpty()) {
+					try {
+						// In Android there is no strictly defined confirmation key, hence DPAD_CENTER may have done nothing.
+						// If so, send an alternative key code as a final resort.
+						Thread.sleep(80);
+						String newText = textField.getTextBeforeCursor() + textField.getTextAfterCursor();
+						if (newText.equals(oldText)) {
+							sendDownUpKeyEvents(KeyEvent.KEYCODE_ENTER);
+						}
+					} catch (InterruptedException e) {
+						// This thread got interrupted. Assume it's because the connected application has taken an action
+						// after receiving DPAD_CENTER, so we don't need to do anything else.
+						return true;
 					}
-				} catch (InterruptedException e) {
-					// This thread got interrupted. Assume it's because the connected application has taken an action
-					// after receiving DPAD_CENTER, so we don't need to do anything else.
-					return true;
 				}
 
 				return true;

--- a/src/io/github/sspanak/tt9/ime/helpers/TextField.java
+++ b/src/io/github/sspanak/tt9/ime/helpers/TextField.java
@@ -335,7 +335,7 @@ public class TextField {
 			return field.actionId;
 		}
 
-		int standardAction = field.imeOptions & (EditorInfo.IME_MASK_ACTION | EditorInfo.IME_FLAG_NO_ENTER_ACTION);
+		int standardAction = field.imeOptions & (EditorInfo.IME_MASK_ACTION | EditorInfo.IME_FLAG_NO_ENTER_ACTION | EditorInfo.IME_FLAG_NAVIGATE_NEXT);
 		switch (standardAction) {
 			case EditorInfo.IME_ACTION_GO:
 			case EditorInfo.IME_ACTION_NEXT:


### PR DESCRIPTION
So on my screen such as this, I was trying to press OK to select an app.
![Screenshot_20230828-001103](https://github.com/sspanak/tt9/assets/11878115/915e5d63-942d-4797-a89b-521e8a205d0b)
Because of the included search bar, it made things tricky. My imeOptions were 134217733, which resulted in it getting filtered to IME_ACTION_NEXT, but IME_ACTION_NEXT was not selecting anything.
By including this extra IME_FLAG, it is getting filtered to its true value and then defaulting to IME_ACTION_ENTER.
However, when it got to oldText and newText, both old and new texts were "" and they were equal. This ran KEYCODE_DPAD_CENTER which was selecting the app, but then running KEYCODE_ENTER which was also valid to select something again on the next screen. My phone was acting as if I double clicked the OK button.

Assuming this logic here is used to send messages, I added a check to make sure oldText is not "". If it is, there isn't anything in a text message box, so don't perform the system ENTER action.