### PR TITLE
Allows input view to hide

### DIFF
--- a/src/io/github/sspanak/tt9/ime/TraditionalT9.java
+++ b/src/io/github/sspanak/tt9/ime/TraditionalT9.java
@@ -785,6 +785,11 @@ public class TraditionalT9 extends KeyPadHandler {
 
 	@Override
 	protected boolean shouldBeOff() {
-		 return currentInputConnection == null || !isActive || mInputMode.isPassthrough();
+		if (mInputMode == null || currentInputConnection == null || !isActive || mInputMode.isPassthrough()) {
+			updateInputViewShown();
+			return true;
+		} else {
+			return false;
+		}
 	}
 }


### PR DESCRIPTION
Problem:
On my TCL Flip 2, when I would scroll up in text conversations, cursor moving off of the text box and highlighting the messages, the bottom keyboard soft keys would still show. It was taking up a considerate amount of space:
![Screenshot_20230907-120344](https://github.com/sspanak/tt9/assets/11878115/8f438655-6b1e-4e49-9ec4-46a109e0d833)
Solution:
Now when pressing up arrow onkeyUp>ShouldBeOff() evaluates the conditions and calls updateInputViewShown() which is hiding the soft keys.
And when user goes back down to the text box, it shows the soft keys again.
![Screenshot_20230907-120138](https://github.com/sspanak/tt9/assets/11878115/b1f142ac-8e78-4e29-9a71-3454873ff1ca)
![Screenshot_20230907-120133](https://github.com/sspanak/tt9/assets/11878115/dc8e66bc-9483-4c9c-8fac-bb7778364b03)

I was also getting crashes for instances where I re-open my messaging app and mInputMode was null, however it was calling mInputMode.isPassthrough() and getting an error. Possibly due to recent changes in isActive, so I just added a conditional to shouldBeOff to check whether mInputMode is already null, before checking if it is passthrough.