### PR TITLE
Backspace Handling

### DIFF
--- a/src/io/github/sspanak/tt9/ime/KeyPadHandler.java
+++ b/src/io/github/sspanak/tt9/ime/KeyPadHandler.java
@@ -124,7 +124,6 @@ abstract class KeyPadHandler extends InputMethodService {
 			return true;
 		}
 
-
 		// start tracking key hold
 		if (Key.isNumber(keyCode)) {
 			event.startTracking();

--- a/src/io/github/sspanak/tt9/ime/KeyPadHandler.java
+++ b/src/io/github/sspanak/tt9/ime/KeyPadHandler.java
@@ -119,11 +119,11 @@ abstract class KeyPadHandler extends InputMethodService {
 //		Logger.d("onKeyDown", "Key: " + event + " repeat?: " + event.getRepeatCount() + " long-time: " + event.isLongPress());
 
 		// "backspace" key must repeat its function when held down, so we handle it in a special way
-		if (Key.isBackspace(settings, keyCode) && onBackspace()) {
-			return isBackspaceHandled = true;
-		} else {
-			isBackspaceHandled = false;
+		if (Key.isBackspace(settings, keyCode)) {
+			onBackspace();
+			return true;
 		}
+
 
 		// start tracking key hold
 		if (Key.isNumber(keyCode)) {
@@ -197,7 +197,7 @@ abstract class KeyPadHandler extends InputMethodService {
 			return true;
 		}
 
-		if (isBackspaceHandled) {
+		if (Key.isBackspace(settings, keyCode)) {
 			return true;
 		}
 


### PR DESCRIPTION
Problem:

On my QIN F21 Pro, which has a very fast processor for this application, I was noticing that at times when I press backspace/back (one button with both functions), the execution of a backspace was sometimes skipped and instead was being processed as back depending on how fast I was typing.
For instance, if I type out a sequence to start building out a word and then rapidly alternate presses between another number and backspace, it would immediately register "back" and I would get a popup on my screen (are you sure you'd like to discard this message?).

I did some debugging and found that in some instances, _isBackspaceHandled_ was false during the onKeyUp event of pressing backspace. Chances are it was failing some checks during onBackspace() because it always had the same keyCode which indicates a backspace.

Solution:

Remove the _isBackspaceHandled_ variable, instead check whether the key is backspace and if so, continue to run onBackspace in the onKeyDown function, but when it comes to onKeyUp, just check whether it is backspace and if so return true.


I have tested on my F21 Pro and it has solved this issue. I also tested with a slower Android 8.1 device and found no issue with this change. Holding down backspace to clear multiple letters works still.