### PR TITLE
Backspace Handling

### DIFF
--- a/src/io/github/sspanak/tt9/ime/KeyPadHandler.java
+++ b/src/io/github/sspanak/tt9/ime/KeyPadHandler.java
@@ -119,10 +119,12 @@ abstract class KeyPadHandler extends InputMethodService {
 //		Logger.d("onKeyDown", "Key: " + event + " repeat?: " + event.getRepeatCount() + " long-time: " + event.isLongPress());
 
 		// "backspace" key must repeat its function when held down, so we handle it in a special way
-		if (Key.isBackspace(settings, keyCode) && onBackspace()) {
-			return isBackspaceHandled = true;
-		} else {
-			isBackspaceHandled = false;
+		if (Key.isBackspace(settings, keyCode)) {
+			if (onBackspace()) {
+				return isBackspaceHandled = true;
+			} else {
+				isBackspaceHandled = false;
+			}
 		}
 
 		// start tracking key hold
@@ -197,7 +199,7 @@ abstract class KeyPadHandler extends InputMethodService {
 			return true;
 		}
 
-		if (isBackspaceHandled) {
+		if (Key.isBackspace(settings, keyCode) && isBackspaceHandled) {
 			return true;
 		}
 


### PR DESCRIPTION
Problem:

On my QIN F21 Pro, which has a very fast processor for this application, I was noticing that at times when I press backspace/back (one button with both functions), the execution of a backspace was sometimes skipped and instead was being processed as back depending on how fast I was typing.
For instance, if I rapidly alternate presses between another number and backspace, it would immediately register "back" and I would get a popup on my screen (are you sure you'd like to discard this message?).

I did some debugging of onKeyDown and onKeyUp and found that in some instances, isBackspaceHandled was false during the onKeyUp event for backspace. 

```
Key: 4 is my backspace key, Key: 10 is my 3(DEF) key

2024-02-01 14:52:46.826  4651-4651  tt9/onKeyDown           io.github.sspanak.tt9                D  Key: 4 repeat?: 0 long-time: false
2024-02-01 14:52:46.944  4651-4651  tt9/onKeyDown           io.github.sspanak.tt9                D  Key: 10 repeat?: 0 long-time: false
--at this point, 3 was pressed, processed, and isBackspaceHandled was set to false before executing onKeyUp. When set to false, it passes isBack() since my back key has two functions.
2024-02-01 14:52:46.955  4651-4651  tt9/onKeyUp             io.github.sspanak.tt9                D  Key: 4 repeat?: 0
```

Solution:
1. Remove the ability for a non-backspace key to set isBackspaceHandled to false.
Check whether the key is backspace and if so, run onBackspace(). If that returns true, then set isBackspaceHandled to true. If not, meaning the backspace key was pressed but did not delete anything, then set it to false.

2. Check for more than just isBackspaceHandled in onKeyUp
When it comes to onKeyUp, also check if the key pressed is backspace. This is because after a successful deletion, isBackspaceHandled will remain true. We need other keys to work in the meantime.

I have tested on my F21 Pro and it has solved this issue. I also tested with a slower Android 8.1 device and found no issue with this change. Holding down backspace to clear multiple letters works still.

Let me know if you have any questions about this. I hope I explained it well.
