### PR TITLE
Smooth language change (updated version)

### DIFF
--- a/app/src/main/java/io/github/sspanak/tt9/ime/modes/ModeABC.java
+++ b/app/src/main/java/io/github/sspanak/tt9/ime/modes/ModeABC.java
@@ -29,8 +29,8 @@ public class ModeABC extends InputMode {
 			reset();
 			autoAcceptTimeout = 0;
 			digitSequence = String.valueOf(number);
-			suggestions.add(language.getKeyNumber(number));
 			shouldSelectNextLetter = false;
+			suggestions.add(language.getKeyNumber(number));
 		} else if (repeat > 0) {
 			autoAcceptTimeout = settings.getAbcAutoAcceptTimeout();
 			shouldSelectNextLetter = true;
@@ -38,9 +38,9 @@ public class ModeABC extends InputMode {
 			reset();
 			autoAcceptTimeout = settings.getAbcAutoAcceptTimeout();
 			digitSequence = String.valueOf(number);
+			shouldSelectNextLetter = false;
 			suggestions.addAll(language.getKeyCharacters(number));
 			suggestions.add(language.getKeyNumber(number));
-			shouldSelectNextLetter = false;
 		}
 
 		return true;
@@ -49,6 +49,14 @@ public class ModeABC extends InputMode {
 	@Override
 	protected String adjustSuggestionTextCase(String word, int newTextCase) {
 		return newTextCase == CASE_UPPER ? word.toUpperCase(language.getLocale()) : word.toLowerCase(language.getLocale());
+	}
+
+	private void refreshSuggestions() {
+		if (digitSequence.isEmpty()) {
+			suggestions.clear();
+		} else {
+			onNumber(digitSequence.charAt(0) - '0', false, 0);
+		}
 	}
 
 	@Override
@@ -70,6 +78,9 @@ public class ModeABC extends InputMode {
 		if (language.hasUpperCase()) {
 			allowedTextCases.add(CASE_UPPER);
 		}
+
+		refreshSuggestions();
+		shouldSelectNextLetter = true; // do not accept any previous suggestions after loading the new ones
 	}
 
 	@Override public int getSequenceLength() { return 1; }

--- a/app/src/main/java/io/github/sspanak/tt9/languages/Language.java
+++ b/app/src/main/java/io/github/sspanak/tt9/languages/Language.java
@@ -266,6 +266,29 @@ public class Language implements Comparable<Language> {
 	}
 
 
+	/**
+	 * Checks whether the given word contains characters outside of the language alphabet.
+	 */
+	public boolean isValidWord(String word) {
+		if (word == null || word.isEmpty() || (word.length() == 1 && Character.isDigit(word.charAt(0)))) {
+			return true;
+		}
+
+		String lowerCaseWord = word.toLowerCase(locale);
+		if (characterKeyMap.isEmpty()) {
+			generateCharacterKeyMap();
+		}
+
+		for (int i = 0; i < lowerCaseWord.length(); i++) {
+			if (!characterKeyMap.containsKey(lowerCaseWord.charAt(i))) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+
 	@NonNull
 	@Override
 	public String toString() {

--- a/app/src/main/java/io/github/sspanak/tt9/ui/UI.java
+++ b/app/src/main/java/io/github/sspanak/tt9/ui/UI.java
@@ -7,10 +7,15 @@ import android.os.Looper;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+
 import io.github.sspanak.tt9.ime.TraditionalT9;
+import io.github.sspanak.tt9.languages.Language;
 import io.github.sspanak.tt9.preferences.PreferencesActivity;
 
 public class UI {
+	private static Toast toastLang = null;
+
 	public static void showAddWordDialog(TraditionalT9 tt9, int language, String currentWord) {
 		Intent intent = new Intent(tt9, PopupDialogActivity.class);
 		intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
@@ -92,5 +97,16 @@ public class UI {
 
 	public static void toastLong(Context context, CharSequence msg) {
 		Toast.makeText(context, msg, Toast.LENGTH_LONG).show();
+	}
+
+	public static void toastLanguage(@NonNull Context context, @NonNull Language language) {
+		if (toastLang != null) {
+			toastLang.cancel();
+		}
+
+		// we recreate the toast, because if set new text, when it is fading out,
+		// the new text is discarded
+		toastLang = Toast.makeText(context, language.getName(), Toast.LENGTH_SHORT);
+		toastLang.show();
 	}
 }


### PR DESCRIPTION
Closes #238

This is an updated version of #238 by @flaviozavan. There are no functional differences, only resolved conflicts with the current `master`.