### PR TITLE
Kyocera Default 'Message' App Support

### DIFF
--- a/app/src/main/java/io/github/sspanak/tt9/ime/helpers/AppHacks.java
+++ b/app/src/main/java/io/github/sspanak/tt9/ime/helpers/AppHacks.java
@@ -58,6 +58,18 @@ public class AppHacks {
 		);
 	}
 
+	/**
+	 * isAndroidMMS
+	 * Android Messages on Kyocera devices will register the OK key as both ENTER and DPAD_CENTER when sending a message using TT9. This results
+	 * in an attempt to double send causing an 'Empty Message' error page to pop up. 
+	 */
+	private boolean isAndroidMMS() {
+		return isAppField(
+			"com.android.mms",
+			EditorInfo.TYPE_CLASS_TEXT | EditorInfo.TYPE_TEXT_FLAG_MULTI_LINE | EditorInfo.TYPE_TEXT_FLAG_CAP_SENTENCES
+		);
+	}
+
 
 	private boolean isGoogleChat() {
 		return isAppField(
@@ -124,6 +136,8 @@ public class AppHacks {
 			return onEnterFbMessenger();
 		} else if (isGoogleChat()) {
 			return onEnterGoogleChat();
+		} else if (isAndroidMMS()) {
+			return onEnterAndroidMMS();
 		}
 
 		return onEnterDefault();
@@ -182,6 +196,26 @@ public class AppHacks {
 
 		if (settings.getFbMessengerHack()) {
 			sendDownUpKeyEvents(KeyEvent.KEYCODE_ENTER);
+		} else {
+			// in case the setting is disabled, just type a new line as one would expect
+			inputConnection.commitText("\n", 1);
+		}
+
+		return true;
+	}
+
+	/**
+	 * onEnterAndroidMMS
+	 * The Messages app will send a message on DPAD_CENTER. TT9 will also input ENTER by default, causing a double send.
+	 * To fix this behaviour, TT9 should do nothing if enter is pressed in this context. 
+	 */
+	private boolean onEnterAndroidMMS() {
+		if (inputConnection == null || textField == null || !textField.isThereText()) {
+			return false;
+		}
+
+		if (settings.getAndroidMMSHack()) {
+			// Do nothing if hack is enabled
 		} else {
 			// in case the setting is disabled, just type a new line as one would expect
 			inputConnection.commitText("\n", 1);

--- a/app/src/main/java/io/github/sspanak/tt9/ime/helpers/AppHacks.java
+++ b/app/src/main/java/io/github/sspanak/tt9/ime/helpers/AppHacks.java
@@ -61,7 +61,7 @@ public class AppHacks {
 	/**
 	 * isAndroidMMS
 	 * Android Messages on Kyocera devices will register the OK key as both ENTER and DPAD_CENTER when sending a message using TT9. This results
-	 * in an attempt to double send causing an 'Empty Message' error page to pop up. 
+	 * in an attempt to double send causing an 'Empty Message' error page to pop up.
 	 */
 	private boolean isAndroidMMS() {
 		return isAppField(
@@ -207,7 +207,7 @@ public class AppHacks {
 	/**
 	 * onEnterAndroidMMS
 	 * The Messages app will send a message on DPAD_CENTER. TT9 will also input ENTER by default, causing a double send.
-	 * To fix this behaviour, TT9 should do nothing if enter is pressed in this context. 
+	 * To fix this behaviour, TT9 should do nothing if enter is pressed in this context.
 	 */
 	private boolean onEnterAndroidMMS() {
 		if (inputConnection == null || textField == null || !textField.isThereText()) {
@@ -215,10 +215,10 @@ public class AppHacks {
 		}
 
 		if (settings.getAndroidMMSHack()) {
-			// Do nothing if hack is enabled
+			sendDownUpKeyEvents(KeyEvent.KEYCODE_DPAD_CENTER);
 		} else {
-			// in case the setting is disabled, just type a new line as one would expect
-			inputConnection.commitText("\n", 1);
+			// in case the setting is disabled, use default behavior
+			onEnterDefault();
 		}
 
 		return true;

--- a/app/src/main/java/io/github/sspanak/tt9/preferences/SettingsStore.java
+++ b/app/src/main/java/io/github/sspanak/tt9/preferences/SettingsStore.java
@@ -319,6 +319,10 @@ public class SettingsStore {
 		return prefs.getBoolean("pref_hack_google_chat", false);
 	}
 
+	public boolean getAndroidMMSHack() {
+			return prefs.getBoolean("pref_hack_android_mms", false);
+	}
+
 	/**
 	 * Protection against faulty devices, that sometimes send two (or more) click events
 	 * per a single key press, which absolutely undesirable side effects.

--- a/app/src/main/java/io/github/sspanak/tt9/preferences/screens/setup/SetupScreen.java
+++ b/app/src/main/java/io/github/sspanak/tt9/preferences/screens/setup/SetupScreen.java
@@ -62,6 +62,11 @@ public class SetupScreen extends BaseScreenFragment {
 			hackFBMessenger.setEnabled(isTT9On);
 		}
 
+		Preference hackAndroidMMS = findPreference("pref_hack_android_mms");
+		if (hackAndroidMMS != null) {
+			hackAndroidMMS.setEnabled(isTT9On);
+		}
+
 		ItemKeyPadDebounceTime item = new ItemKeyPadDebounceTime(activity, findPreference(ItemKeyPadDebounceTime.NAME));
 		item.populate().preview();
 		if (isTT9On) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,6 +49,7 @@
 	<string name="pref_double_zero_char">Character for Double 0-key Press</string>
 	<string name="pref_hack_google_chat">Send messages with \"OK\" in Google Chat</string>
 	<string name="pref_hack_fb_messenger">Send with \"OK\" in Facebook Messenger</string>
+	<string name="pref_hack_android_mms">Fix double send in Android Message</string>
 	<string name="pref_hack_key_pad_debounce_time">Accidental Key Repeat Protection</string>
 	<string name="pref_hack_key_pad_debounce_off">Off</string>
 	<string name="pref_show_soft_function_keys">Show On-Screen Keys</string>

--- a/app/src/main/res/xml/prefs_screen_setup.xml
+++ b/app/src/main/res/xml/prefs_screen_setup.xml
@@ -37,6 +37,12 @@
 		app:layout="@layout/pref_switch"
 		app:title="@string/pref_hack_fb_messenger"/>
 
+	<SwitchPreferenceCompat
+		app:defaultValue="false"
+		app:key="pref_hack_android_mms"
+		app:layout="@layout/pref_switch"
+		app:title="@string/pref_hack_android_mms"/>	
+
 	<DropDownPreference
 		app:iconSpaceReserved="false"
 		app:key="pref_key_pad_debounce_time"


### PR DESCRIPTION
This MR fixes behavior on the Kyocera DuraXA flip phone where sending a message with `DPAD_CENTER` results in a double send attempt, resulting in an error screen after each message is sent. 

A new app hack has been added to only send the `KEYCODE_DPAD_CENTER` event, and not attempt the `KEYCODE_ENTER` code that is present in `onEnterDefault()`. A toggle switch inside of the 'Initial Setup' menu has been added. 

I did not add menu strings for other (non-english) locales. 