### PR TITLE
Add Hungarian dictionary

### DIFF
--- a/app/languages/definitions/Hungarian.yml
+++ b/app/languages/definitions/Hungarian.yml
@@ -1,0 +1,13 @@
+locale: hu-HU
+dictionaryFile: hu-utf8.csv
+layout:
+  - [SPECIAL] # 0
+  - [PUNCTUATION] # 1
+  - [a, á, b, c] # 2
+  - [d, e, é, f] # 3
+  - [g, h, i, í] # 4
+  - [j, k, l] # 5
+  - [m, n, o, ó, ö, ő] # 6
+  - [p, q, r, s] # 7
+  - [t, u, ú, ü, ű, v] # 8
+  - [w, x, y, z] # 9

--- a/app/languages/definitions/Hungarian.yml
+++ b/app/languages/definitions/Hungarian.yml
@@ -1,5 +1,6 @@
 locale: hu-HU
 dictionaryFile: hu-utf8.csv
+abcString: abc
 layout:
   - [SPECIAL] # 0
   - [PUNCTUATION] # 1

--- a/app/src/main/java/io/github/sspanak/tt9/ui/main/keys/SoftNumberKey.java
+++ b/app/src/main/java/io/github/sspanak/tt9/ui/main/keys/SoftNumberKey.java
@@ -113,7 +113,7 @@ public class SoftNumberKey extends SoftKey {
 
 		StringBuilder sb = new StringBuilder();
 		ArrayList<String> chars = language.getKeyCharacters(number);
-		for (int i = 0; i < 5 && i < chars.size(); i++) {
+		for (int i = 0; sb.length() < 5 && i < chars.size(); i++) {
 			String currentLetter = chars.get(i);
 			if (
 				(isLatinBased && currentLetter.charAt(0) > 'z')

--- a/docs/dictionaries/huWordlistReadme.txt
+++ b/docs/dictionaries/huWordlistReadme.txt
@@ -1,0 +1,4 @@
+Lingtrain Hungarian Word Frequency from Kaggle:
+Source: https://www.kaggle.com/datasets/averkij/lingtrain-hungarian-word-frequency
+Version: 2
+License: https://creativecommons.org/licenses/by-sa/4.0/

--- a/docs/dictionaries/huWordlistReadme.txt
+++ b/docs/dictionaries/huWordlistReadme.txt
@@ -1,4 +1,12 @@
-Lingtrain Hungarian Word Frequency from Kaggle:
+Lingtrain Hungarian Word from Kaggle:
 Source: https://www.kaggle.com/datasets/averkij/lingtrain-hungarian-word-frequency
 Version: 2
 License: https://creativecommons.org/licenses/by-sa/4.0/
+
+Wordlist 2 by Domonkos Tikk by courtesy of Typotex
+Source: https://www.winedt.org/dict/Hungarian.zip
+
+Wordlist 3 and frequencies from Openboard project
+Version: 7bf52c1 (2020-01-15)
+Source: https://github.com/openboard-team/openboard
+License: https://github.com/openboard-team/openboard/blob/master/LICENSE


### PR DESCRIPTION
Not sure if this is the best source for words, but I needed something to be able to text faster on my dumb phone. I've been using it for the past week and it works great for me (I did have to clean up the word list a little bit to build an APK, so it's not the exact same one as the source).

Note that I've added letters with special characters in between the normal letters, e.g. `aábc`. This is intentional as it's how I remember old dumb phones working with the Hungarian alphabet and it's logical since we use a lot of these letters.