### PR TITLE
Add 4 new English words + change capitalization of two

### DIFF
--- a/app/languages/dictionaries/en-utf8.csv
+++ b/app/languages/dictionaries/en-utf8.csv
@@ -941,7 +941,7 @@ god	124
 hoe	72
 Goi
 IMG	79
-Ing
+ing
 hog	87
 Hol
 ink	109
@@ -1782,7 +1782,6 @@ wyd
 -per	10
 -ROM	10
 -toc	10
--ing
 AABB
 ACCA	70
 ACCC	70


### PR DESCRIPTION
- Added 'cis': science term (also shows up in compounds as 'cis-' sometimes) + math term + used as an abbreviation for 'cisgender'
- Added '-ing': used when tacking 'ing' onto words that you wouldn't normally see with an 'ing' on the end (like turning a word that's usually only a noun into a verb) -- I do wonder if it might make more sense to just put 'ing' in instead, without the dash? That was almost what I did first
- Added 'convo': I dunno if this one is common enough to be included, I use it a lot in very casual speech + people I know do, but I could have a skewed view of how common it is
- Added 'filesystems': singular 'filesystem' is already here so I thought it was weird that the plural wasn't included
- Changed 'MASH' to 'mash': I think mash as a normal verb/noun is probably more common than MASH, the acronym. 'mash' as shorthand for mashed potatoes, or as mashed animal feed...
- Changed 'Colon' to 'colon': technically these are different words, capital-C being a surname, locaps-c being the body part or the punctuation. I think probably the latter usage is more common than the former?
- Removed 'zoot': this word is mostly pretty wildly uncommon nowadays so I was surprised to see it in the default dictionary at all. I *do* use the similar-but-unrelated word 'zooted' in very casual speech a lot (which is why I noticed it) but I certainly wouldn't think of it as a common enough word to include. See also: [this Google n-gram viewer query for 'zoot suit' and lone 'zoot'](https://books.google.com/ngrams/graph?content=zoot+suit%2Czoot&year_start=1800&year_end=2022&corpus=en&smoothing=3&case_insensitive=false) (this was a later addition hence it not being mentioned in the title, initially I wasn't sure enough to actually remove it, but I figure if you think it should stay then you can just not include that part of my merge req)

Sorry if it was weird to do these in multiple commits. I also don't know if I did the priorities right, I assumed lower number = shows up later in the list? Sorry too if I got sorting wrong.