### PR TITLE
Update Emoji lists

### DIFF
--- a/app/src/main/java/io/github/sspanak/tt9/util/chars/Emoji.java
+++ b/app/src/main/java/io/github/sspanak/tt9/util/chars/Emoji.java
@@ -13,19 +13,23 @@ class Emoji extends Punctuation {
 	final private static ArrayList<ArrayList<String>> Emoji = new ArrayList<>(Arrays.asList(
 		// positive
 		new ArrayList<>(Arrays.asList(
-			"🙂", "😀", "🤣", "🤓", "😎", "😛", "😉"
+		  "🙂", "😊", "😁", "😆", "😅", "🤣", "😛", "😉", "🤓", "😎"
 		)),
 		// negative
 		new ArrayList<>(Arrays.asList(
-			"🙁", "😢", "😭", "😱", "😲", "😳", "😐", "😠"
+			"🙁", "😟", "😢", "😭", "😧", "😱", "😲", "😳", "😠", "😐"
 		)),
 		// hands
 		new ArrayList<>(Arrays.asList(
-			"👍", "👋", "✌️", "👏", "🖖", "🤘", "🤝", "💪", "👎"
+			"👍", "👎", "👋", "👏", "🤞", "✌️", "💪", "🤝", "🤘", "🖖"
 		)),
-		// emotions
+		// love
 		new ArrayList<>(Arrays.asList(
-			"❤", "🤗", "😍", "😘", "😇", "😈", "🍺", "🎉", "🥱", "🤔", "🥶", "😬"
+			"❤", "🤗", "😘", "😍", "🤩", "🫂", "🫶", "❤️‍🔥", "💗", "💋"
+		))
+		// misc
+		new ArrayList<>(Arrays.asList(
+			"😬", "🥺", "😇", "😈", "🥱", "🤔", "🥶", "🥵", "🔥", "🎉"
 		))
 	));
 


### PR DESCRIPTION
I opened #1182 about being able to customise the emoji lists from within the app, but in the meantime, I thought why not proposing some of my most used emojis to the default lists.

Notably 😊, 😁, 😆, 😅, 🤞, 🤩, 🫂.

Then I got carried away and tried to make sense of it all:
- Each list is now exactly 10 emojis
- Changed some of the order to make it a little more logical and/or having more likely to be used emojis to the left
- Split the `emotions` list into `love` and `misc`, bringing it to 5 lists (50 emojis total)
- I filled the love list with 🫶, ❤️‍🔥, 💗, 💋 from https://emojipedia.org/most-popular
- Also added from there 🔥 to misc, as well as 🥵 to counter 🥶
- Only emoji I removed to fit neatly into 10 is 🍺, fun but maybe not universally used?

This is just a quick job and could be improved. Maybe some actual global stats for most used emoji could be used to choose the 50 or so most relevant? Maybe they could be ordered the same way they are in actual emoji pickers? But for now, this does the job for me. Feel free to approve it or not! 😊